### PR TITLE
Fix optional length in read_jsonlines

### DIFF
--- a/llava_next_autocheck.py
+++ b/llava_next_autocheck.py
@@ -25,7 +25,11 @@ def main():
     length = None
     if args.end_pos != -1:
         length = args.end_pos - args.start_pos
-    data = read_jsonlines(args.ds_name, args.start_pos, length)
+
+    if length is not None:
+        data = read_jsonlines(args.ds_name, args.start_pos, length)
+    else:
+        data = read_jsonlines(args.ds_name, args.start_pos)
 
     tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
     model = AutoModelForCausalLM.from_pretrained(args.checkpoint, device_map='auto')

--- a/utils/file_io.py
+++ b/utils/file_io.py
@@ -1,5 +1,6 @@
 import json
 import jsonlines
+from typing import Optional
 
 def write_jsonlines(file: str, dataset: list):
     with jsonlines.open(file, 'w') as writer:
@@ -16,7 +17,7 @@ def read_json(path):
 
     return data
 
-def read_jsonlines(file: str, index_begin: int = 0, index_all: int = -1):
+def read_jsonlines(file: str, index_begin: int = 0, index_all: Optional[int] = -1):
     """Read a jsonlines file with optional start and end indices.
 
     Parameters
@@ -28,6 +29,9 @@ def read_jsonlines(file: str, index_begin: int = 0, index_all: int = -1):
     index_all : int, optional
         The number of records to read. ``-1`` means reading to the end.
     """
+
+    if index_all is None:
+        index_all = -1
 
     dataset = []
     with jsonlines.open(file, 'r') as reader:

--- a/utils/spacy_divide.py
+++ b/utils/spacy_divide.py
@@ -19,7 +19,11 @@ def main():
     length = None
     if args.end != -1:
         length = args.end - args.start
-    data = read_jsonlines(args.input, args.start, length)
+
+    if length is not None:
+        data = read_jsonlines(args.input, args.start, length)
+    else:
+        data = read_jsonlines(args.input, args.start)
     for item in data:
         item["sub_sents"] = get_sub_clauses(item.get("answer", ""))
     write_jsonlines(args.output, data)


### PR DESCRIPTION
## Summary
- allow `read_jsonlines` to accept `None` for `index_all`
- call `read_jsonlines` safely in `spacy_divide.py`
- handle optional `index_all` in `llava_next_autocheck.py`

## Testing
- `python utils/spacy_divide.py --input dummy_answers.jsonl --output dummy_divide.jsonl --start 0 --end -1`
- `python llava_next_autocheck.py --checkpoint sshleifer/tiny-gpt2 --ds_name dummy_divide.jsonl --answer_file dummy_checked.jsonl --start_pos 0 --end_pos -1 --is_yesno`

------
https://chatgpt.com/codex/tasks/task_e_687235993f70833082708a4d91d43f9c