### PR TITLE
Add jsonl support for dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ We introduce RLAIF-V, a novel framework that aligns MLLMs in a fully open-source
 ## Dataset
 
 We present the [RLAIF-V Dataset](https://huggingface.co/datasets/openbmb/RLAIF-V-Dataset), which is an AI generated preference dataset covering diverse range of tasks and domains. This open-source multimodal preference datasets contains **83,132 high-quality comparison pairs**. The dataset contains the generated preference pairs in each training iteration of different models, including LLaVA 1.5 7B, OmniLMM 12B and MiniCPM-V.
+You can also train with your own jsonl file by providing it to `RLAIFVDataset` through the `--jsonl_file` argument.
 
 ## Install
 
@@ -180,7 +181,8 @@ bash ./script/data_gen/run_data_pipeline_llava15_minicpmv.sh
 
 If you can access huggingface dataset, you can skip this step, we will automatically download the [RLAIF-V Dataset](https://huggingface.co/datasets/openbmb/RLAIF-V-Dataset).
 
-If you already downloaded the dataset, you can replace 'openbmb/RLAIF-V-Dataset' to your dataset path [here](muffin/data/datasets.py#L38) at Line 38.
+If you already downloaded the dataset, you can replace `openbmb/RLAIF-V-Dataset` with your local dataset path in `muffin/data/datasets.py`.
+If you have your own jsonl preference data, pass the file path to `--jsonl_file` when running the training script. Log probabilities will be computed automatically.
 
 2. Training
 
@@ -207,10 +209,10 @@ bash ./script/train/llava15_train_lora.sh
 To reproduce the iterative training process in the paper, you need to do the following steps for 4 times:
 - **S1. Data generation.**
 
-  Follow the instructions in [data generation](https://github.com/RLHF-V/RLAIF-V?tab=readme-ov-file#data-generation) to generate preference pairs for the base model. Convert the generated jsonl file to huggingface parquet.
+  Follow the instructions in [data generation](https://github.com/RLHF-V/RLAIF-V?tab=readme-ov-file#data-generation) to generate preference pairs for the base model. The resulting jsonl file can be directly used with `--jsonl_file`.
 - **S2. Change training config.**
 
-  In dataset code, replace `'openbmb/RLAIF-V-Dataset'` [here](muffin/data/datasets.py#L38) to your data path.
+  In the dataset code, replace `openbmb/RLAIF-V-Dataset` with your local dataset path if needed.
 
   In [training script](script/train/llava15_train.sh), replace `--data_dir` with a new directory, replace `--model_name_or_path` with the base model path, set `--max_step` to the number of steps for 4 epoch, set `--save_steps` to the number of steps for 1/4 epoch.
 - **S3. Do DPO training.**

--- a/muffin/data/datasets.py
+++ b/muffin/data/datasets.py
@@ -26,7 +26,8 @@ def bytes_to_PIL_image(img_buffer):
 
 class RLAIFVDataset(torch_data.Dataset):
     def __init__(self, data_dir: str, reference_model=None,
-                 tokenizer=None, image_token_len=None, img_processor=None, use_im_start_end=True, is_llava15=False):
+                 tokenizer=None, image_token_len=None, img_processor=None,
+                 use_im_start_end=True, is_llava15=False, jsonl_file: str = None):
         super().__init__()
 
         if not op.exists(data_dir):
@@ -35,21 +36,37 @@ class RLAIFVDataset(torch_data.Dataset):
         data_path = [file for file in os.listdir(data_dir) if file.endswith('.parquet') and 'logp' in file]
         self.data_path = data_dir
 
-        if len(data_path) == 0:
-            assert reference_model is not None, "`reference_model` is mandatory when logps do not exist."
-
-            if not op.exists('./RLAIF-V-Dataset'):
-                os.mkdir('./RLAIF-V-Dataset')
-            hf_data = hf_datasets.load_dataset('openbmb/RLAIF-V-Dataset', cache_dir='./RLAIF-V-Dataset')['train'].cast_column("image", hf_datasets.Image(decode=False))
-
-            inference_logp(reference_model, tokenizer, hf_data, self.data_path,
-                            image_token_len, img_processor, use_im_start_end, is_llava15=is_llava15)
-
-            torch.distributed.barrier()
-
-            self.data = hf_datasets.load_dataset(data_dir)['train'].cast_column("image", hf_datasets.Image(decode=False))
+        if jsonl_file is not None:
+            hf_data = hf_datasets.load_dataset('json', data_files={'train': jsonl_file})['train']
+            if 'image' in hf_data.column_names:
+                try:
+                    hf_data = hf_data.cast_column('image', hf_datasets.Image(decode=False))
+                except Exception:
+                    pass
+            if 'logps' not in hf_data.column_names:
+                assert reference_model is not None, "`reference_model` is mandatory when logps do not exist."
+                inference_logp(reference_model, tokenizer, hf_data, self.data_path,
+                                image_token_len, img_processor, use_im_start_end, is_llava15=is_llava15)
+                torch.distributed.barrier()
+                self.data = hf_datasets.load_dataset(data_dir)['train'].cast_column("image", hf_datasets.Image(decode=False))
+            else:
+                self.data = hf_data
         else:
-            self.data = hf_datasets.load_dataset(data_dir)['train'].cast_column("image", hf_datasets.Image(decode=False))
+            if len(data_path) == 0:
+                assert reference_model is not None, "`reference_model` is mandatory when logps do not exist."
+
+                if not op.exists('./RLAIF-V-Dataset'):
+                    os.mkdir('./RLAIF-V-Dataset')
+                hf_data = hf_datasets.load_dataset('openbmb/RLAIF-V-Dataset', cache_dir='./RLAIF-V-Dataset')['train'].cast_column("image", hf_datasets.Image(decode=False))
+
+                inference_logp(reference_model, tokenizer, hf_data, self.data_path,
+                                image_token_len, img_processor, use_im_start_end, is_llava15=is_llava15)
+
+                torch.distributed.barrier()
+
+                self.data = hf_datasets.load_dataset(data_dir)['train'].cast_column("image", hf_datasets.Image(decode=False))
+            else:
+                self.data = hf_datasets.load_dataset(data_dir)['train'].cast_column("image", hf_datasets.Image(decode=False))
 
         self.line_idx = list(range(len(self.data)))
 

--- a/muffin/train/train_llava15_lora.py
+++ b/muffin/train/train_llava15_lora.py
@@ -68,6 +68,7 @@ class DataArguments:
     data_source_weights: str = '100'
     eval_data_source_names: Optional[str] = field(default=None)
     data_dir: str = './RLAIF-V-Dataset/'
+    jsonl_file: Optional[str] = None
     kto_win_data_source_names: str = '100'
     kto_win_data_source_weights: str = '100'
     kto_rej_data_source_names : str = '100'
@@ -211,11 +212,21 @@ class DPODataset(Dataset):
                  tokenizer: transformers.PreTrainedTokenizer,
                  data_dir: str,
                  multimodal_cfg: dict,
-                 reference_model = None):
+                 reference_model = None,
+                 jsonl_file: str = None):
         super(DPODataset, self).__init__()
 
         self.tokenizer = tokenizer
-        self.list_data_dict = RLAIFVDataset(data_dir, reference_model, tokenizer,multimodal_cfg['image_token_len'], multimodal_cfg['image_processor'], multimodal_cfg['use_im_start_end'], is_llava15=True)
+        self.list_data_dict = RLAIFVDataset(
+            data_dir,
+            reference_model,
+            tokenizer,
+            multimodal_cfg['image_token_len'],
+            multimodal_cfg['image_processor'],
+            multimodal_cfg['use_im_start_end'],
+            is_llava15=True,
+            jsonl_file=jsonl_file,
+        )
         self.multimodal_cfg = multimodal_cfg
         self.multimodal_cfg['keep_image_tag'] = True
 
@@ -233,6 +244,7 @@ class DPODataset(Dataset):
 def make_dpo_data_module(tokenizer, data_args,reference_model):
     train_dataset = DPODataset(tokenizer=tokenizer,
                                data_dir=data_args.data_dir,
+                               jsonl_file=data_args.jsonl_file,
                                multimodal_cfg=dict(
                                    is_multimodal=data_args.is_multimodal,
                                    image_token_len=data_args.image_token_len,
@@ -257,6 +269,7 @@ def make_dpo_data_module(tokenizer, data_args,reference_model):
         for name in data_args.eval_data_source_names:
             eval_dataset = DPODataset(tokenizer=tokenizer,
                                       data_dir=data_args.data_dir,
+                                      jsonl_file=data_args.jsonl_file,
                                       multimodal_cfg=dict(
                                           is_multimodal=data_args.is_multimodal,
                                           image_token_len=data_args.image_token_len,

--- a/script/train/llava15_train_lora.sh
+++ b/script/train/llava15_train_lora.sh
@@ -7,6 +7,7 @@ deepspeed ./muffin/train/train_llava15_lora.py \
     --deepspeed ./script/zero2.json  \
     --model_name_or_path liuhaotian/llava-v1.5-7b \
     --data_dir ./RLAIF-V-Dataset_logps/ \
+    # --jsonl_file your_data.jsonl \
     --image_folder not_used \
     --vision_tower openai/clip-vit-large-patch14-336 \
     --mm_use_im_start_end False \


### PR DESCRIPTION
## Summary
- allow `RLAIFVDataset` to load a custom jsonl file and compute logps
- propagate `jsonl_file` option through the training pipeline
- document the option in README and lora training script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833c8126448330869c56b251889df8